### PR TITLE
Fixed unhandled exception if trying to browse for a removed media / invalid id

### DIFF
--- a/lib/services/ContentDirectory.coffee
+++ b/lib/services/ContentDirectory.coffee
@@ -194,6 +194,7 @@ class ContentDirectory extends Service
   fetchObject: (id, cb) ->
     @redis.hgetall id, (err, object) ->
       return cb new SoapError 501 if err?
+      return cb new SoapError 701 unless object
       return cb new SoapError 701 unless Object.keys(object).length > 0
       cb null, object
 


### PR DESCRIPTION
Browsing for an id that no longer exists in the redis cache caused app to crash